### PR TITLE
Codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,3 +25,4 @@ exclude_paths:
 - test/
 - app/bower_components
 - node_modules/
+- hooks/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,27 @@
+engines:
+  bundler-audit:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - javascript
+  eslint:
+    enabled: false
+  fixme:
+    enabled: true
+ratings:
+  paths:
+  - Gemfile.lock
+  - "**.inc"
+  - "**.js"
+  - "**.jsx"
+  - "**.module"
+  - "**.php"
+  - "**.py"
+  - "**.rb"
+exclude_paths:
+- config/
+- test/
+- app/bower_components
+- node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -262,7 +262,8 @@ module.exports = function (grunt) {
         coverageReporter: {
           reporters: [
             { type: 'html', dir: 'coverage/' },
-            { type: 'text-summary' }
+            { type: 'text-summary' },
+            { type: 'lcovonly', subdir: '.', file: 'report-lcovonly.txt' },
           ]
         },
         ngHtml2JsPreprocessor: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "postinstall": "bash ./post_install.sh",
-    "test": "grunt test:ci"
+    "test": "grunt test:ci && CODECLIMATE_REPO_TOKEN=$CodeClimateToken ./node_modules/.bin/codeclimate-test-reporter < coverage/report-lcovonly.txt"
   },
   "dependencies": {
     "bower": "^1.6.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
+    "codeclimate-test-reporter": "^0.3.3",
     "cordova": "~4.2.0",
     "elementtree": "0.1.6",
     "glob": "~4.3.5",


### PR DESCRIPTION
http://nodriza.shiriculapo.com/issues/712
Por el momento vamos a deshabilitar `eslint`.
Tenemos q migrar de `jshint` a `eslint`. No sé con qué prioridad @macool 
