### PR TITLE
se agrego nav en index de address

### DIFF
--- a/app/scripts/controllers/profile/profile-info-controller.js
+++ b/app/scripts/controllers/profile/profile-info-controller.js
@@ -47,7 +47,7 @@
         .then(function(resp) {
           piVm.user = resp.data.data;
           $scope.$emit('currentUserUpdated', piVm.user);
-          
+
           $ionicPopup.alert({
             title: 'Éxito',
             template: '{{::("user.successUpdateProfile"|translate)}}'

--- a/app/styles/customer/profile-form.scss
+++ b/app/styles/customer/profile-form.scss
@@ -1,0 +1,7 @@
+.customer-profile-form {
+  .image-preview {
+    .img-wrapper {
+      margin: auto;
+    }
+  }
+}

--- a/app/styles/customer/show.scss
+++ b/app/styles/customer/show.scss
@@ -26,10 +26,13 @@
 }
 
 .addresses-wrapper {
-  // fix scrolling
-  height: auto;
-  bottom: initial;
-  padding-bottom: 20px;
+  top: 0;
+
+  &--fix-scroll {
+    height: auto;
+    bottom: initial;
+    padding-bottom: 15px;
+  }
 
   .address-wrapper {
     .resource-detail-title {
@@ -37,4 +40,8 @@
       margin-bottom: 5px;
     }
   }
+}
+
+.addresses-wrapper--parent {
+  overflow: initial;
 }

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -42,6 +42,7 @@
 @import "categories/index";
 @import "categories/show";
 @import "customer/show";
+@import "customer/profile-form";
 @import "item/index";
 @import "item/form";
 @import "item/show";

--- a/app/templates/profile/addresses/actions.jade
+++ b/app/templates/profile/addresses/actions.jade
@@ -1,7 +1,6 @@
-ion-view(
+ion-view.addresses-wrapper--parent(
   view-title="{{::('profile.tabs.addresses'|translate)}}"
 )
   ion-nav-title
     .alt-logo
-
   ng-include(src="'templates/profile/addresses/form_template.html'")

--- a/app/templates/profile/addresses/form_template.jade
+++ b/app/templates/profile/addresses/form_template.jade
@@ -2,7 +2,7 @@ form(
   name="pfaVm.addressForm"
   novalidate
 )
-  ion-content.resource-form
+  ion-content.addresses-wrapper.resource-form
     .list.list-inset.fields-wrapper
       legend {{::pfaVm.inUpdateMode ? ("profile.addresses.formLegendUpdate"|translate) : ("profile.addresses.formLegendNew"|translate)}}
 

--- a/app/templates/profile/addresses/index.jade
+++ b/app/templates/profile/addresses/index.jade
@@ -3,17 +3,14 @@ ion-view(
 )
   ion-nav-title
     .alt-logo
-  ion-content.addresses-wrapper(
-    scroll="false"
-  )
+  ion-content
     .address-wrapper(
       ng-repeat="address in ::pfaVm.addresses"
     )
       .list.list-inset.list--no-borders.text-center.actions-wrapper
         button.button.button-clear.button-positive(
-          ng-click="pfaVm.redirectToUpdateAddressView(address.id)"
-        ) {{::('globals.edit'|translate)}}
-
+        ng-click="pfaVm.redirectToUpdateAddressView(address.id)"
+      ) {{::('globals.edit'|translate)}}
       .list.list-inset.list--no-borders.resource-details-table
         p.resource-detail-title {{ address.nombre || address.direccion_uno }}
         .row
@@ -43,5 +40,5 @@ ion-view(
 
     .list.list-inset.list--no-borders.text-center.actions-wrapper
       button.button.button-outline.button-energized(
-        ng-click="pfaVm.redirectToNewAddressView()"
+      ng-click="pfaVm.redirectToNewAddressView()"
       ) {{::("profile.addresses.addAddressBtnText"|translate)}}

--- a/app/templates/profile/addresses/index.jade
+++ b/app/templates/profile/addresses/index.jade
@@ -1,42 +1,47 @@
-ion-content.addresses-wrapper(
-  scroll="false"
+ion-view(
+  view-title="{{::('profile.tabs.addresses'|translate)}}"
 )
-  .address-wrapper(
-    ng-repeat="address in ::pfaVm.addresses"
+  ion-nav-title
+    .alt-logo
+  ion-content.addresses-wrapper(
+    scroll="false"
   )
-    .list.list-inset.list--no-borders.text-center.actions-wrapper
-      button.button.button-clear.button-positive(
-        ng-click="pfaVm.redirectToUpdateAddressView(address.id)"
-      ) {{::('globals.edit'|translate)}}
-    
-    .list.list-inset.list--no-borders.resource-details-table
-      p.resource-detail-title {{ address.nombre || address.direccion_uno }}
-      .row
-        .col.col-50.label {{::('profile.addresses.city'|translate)}}
-        .col.col-50.value {{address.ciudad}}
-      .row
-        .col.col-50.label {{::('profile.addresses.parish'|translate)}}
-        .col.col-50.value {{address.parroquia}}
-      .row
-        .col.col-50.label {{::('profile.addresses.neighborhood'|translate)}}
-        .col.col-50.value {{address.barrio}}
-      .row
-        .col.col-50.label {{::('profile.addresses.addressOne'|translate)}}
-        .col.col-50.value {{address.direccion_uno}}
-      .row
-        .col.col-50.label {{::('profile.addresses.addressTwo'|translate)}}
-        .col.col-50.value {{address.direccion_dos}}
-      .row
-        .col.col-50.label {{::('profile.addresses.zipCode'|translate)}}
-        .col.col-50.value {{address.codigo_postal}}
-      .row
-        .col.col-50.label {{::('profile.addresses.reference'|translate)}}
-        .col.col-50.value {{address.referencia}}
-      .row
-        .col.col-50.label {{::('profile.addresses.telephoneNumber'|translate)}}
-        .col.col-50.value {{address.numero_convencional}}
+    .address-wrapper(
+      ng-repeat="address in ::pfaVm.addresses"
+    )
+      .list.list-inset.list--no-borders.text-center.actions-wrapper
+        button.button.button-clear.button-positive(
+          ng-click="pfaVm.redirectToUpdateAddressView(address.id)"
+        ) {{::('globals.edit'|translate)}}
 
-  .list.list-inset.list--no-borders.text-center.actions-wrapper
-    button.button.button-outline.button-energized(
-      ng-click="pfaVm.redirectToNewAddressView()"
-    ) {{::("profile.addresses.addAddressBtnText"|translate)}}
+      .list.list-inset.list--no-borders.resource-details-table
+        p.resource-detail-title {{ address.nombre || address.direccion_uno }}
+        .row
+          .col.col-50.label {{::('profile.addresses.city'|translate)}}
+          .col.col-50.value {{address.ciudad}}
+        .row
+          .col.col-50.label {{::('profile.addresses.parish'|translate)}}
+          .col.col-50.value {{address.parroquia}}
+        .row
+          .col.col-50.label {{::('profile.addresses.neighborhood'|translate)}}
+          .col.col-50.value {{address.barrio}}
+        .row
+          .col.col-50.label {{::('profile.addresses.addressOne'|translate)}}
+          .col.col-50.value {{address.direccion_uno}}
+        .row
+          .col.col-50.label {{::('profile.addresses.addressTwo'|translate)}}
+          .col.col-50.value {{address.direccion_dos}}
+        .row
+          .col.col-50.label {{::('profile.addresses.zipCode'|translate)}}
+          .col.col-50.value {{address.codigo_postal}}
+        .row
+          .col.col-50.label {{::('profile.addresses.reference'|translate)}}
+          .col.col-50.value {{address.referencia}}
+        .row
+          .col.col-50.label {{::('profile.addresses.telephoneNumber'|translate)}}
+          .col.col-50.value {{address.numero_convencional}}
+
+    .list.list-inset.list--no-borders.text-center.actions-wrapper
+      button.button.button-outline.button-energized(
+        ng-click="pfaVm.redirectToNewAddressView()"
+      ) {{::("profile.addresses.addAddressBtnText"|translate)}}

--- a/app/templates/profile/addresses/index.jade
+++ b/app/templates/profile/addresses/index.jade
@@ -1,9 +1,16 @@
-ion-view(
+ion-view.addresses-wrapper--parent(
   view-title="{{::('profile.tabs.addresses'|translate)}}"
 )
   ion-nav-title
     .alt-logo
-  ion-content
+  ion-content.addresses-wrapper.addresses-wrapper--fix-scroll(
+    scroll="false"
+  )
+    .list.list-inset.list--no-borders.text-center.actions-wrapper
+      button.button.button-outline.button-energized(
+      ng-click="pfaVm.redirectToNewAddressView()"
+      ) {{::("profile.addresses.addAddressBtnText"|translate)}}
+
     .address-wrapper(
       ng-repeat="address in ::pfaVm.addresses"
     )
@@ -37,8 +44,3 @@ ion-view(
         .row
           .col.col-50.label {{::('profile.addresses.telephoneNumber'|translate)}}
           .col.col-50.value {{address.numero_convencional}}
-
-    .list.list-inset.list--no-borders.text-center.actions-wrapper
-      button.button.button-outline.button-energized(
-      ng-click="pfaVm.redirectToNewAddressView()"
-      ) {{::("profile.addresses.addAddressBtnText"|translate)}}

--- a/app/templates/profile/info/edit.jade
+++ b/app/templates/profile/info/edit.jade
@@ -12,14 +12,14 @@ ion-modal-view
     ng-submit="piVm.submitProcess(piVm.userEdit)"
     novalidate
   )
-    ion-content.resource-form
+    ion-content.resource-form.customer-profile-form
       .list.list-inset
         legend {{::("client.formLegend"|translate)}}
 
         label.item.item-input.item-input--no-borders.item-stacked-label
           span.input-label {{::("user.image"|translate)}}
-        .row.images-previews
-          .img-wrapper.col-offset-25.col-50
+        .row.image-preview
+          .img-wrapper
             img( ng-if="piVm.hasImageFile(piVm.userEdit)" 
                   ngf-src="piVm.userEdit.custom_image"
                   style="max-width: 70px; max-height: 70px;border-radius: 50%;"
@@ -35,7 +35,9 @@ ion-modal-view
           accept="image/*"
         )
           .img-placeholder
-          .img-placeholder--legend {{::("user.changeImagen"|translate)}}
+          .text-center
+            .button.button-clear.button-positive.button-small
+              | {{::("user.changeImagen"|translate)}}
 
         show-error(array-messages='piVm.user.custom_image')
 

--- a/app/templates/profile/profile.jade
+++ b/app/templates/profile/profile.jade
@@ -1,5 +1,5 @@
 ion-view(
-  view-title='{{::profile.title|translate}}'
+  view-title="{{::('profile.title')|translate}}"
 )
   ion-nav-title
     .alt-logo

--- a/app/templates/profile/profile.jade
+++ b/app/templates/profile/profile.jade
@@ -5,7 +5,6 @@ ion-view(
     .alt-logo
   ion-content.has-header.show-profile-page(
     scroll="false"
-    overflow-scroll="false"
   )
     .row
       .col.profile-header
@@ -18,7 +17,7 @@ ion-view(
       ion-tabs.tabs-top.tabs-striped
         ion-tab(
           title="{{::('profile.tabs.info'|translate)}}"
-          ui-sref="app.profile.info"
+          ui-sref="app.profile.info.index"
         )
           ion-nav-view(name='menuContent@profileInfo')
         ion-tab(


### PR DESCRIPTION
no se cambio nada en routes.js , sino que pude entender era que existia el padre app , el hijo app.profile , el nieto app.profile.address y los bisnietos bisnieto app.profile.address.index y app.profile.address.update (estos dos ultimos tienen el mismo template action.jade y ese template tiene el un ion-nav donde donde muestra la flecha ) , entonces use el nav-clear pero no funciono, estaba leyendo y vi que el app.profile tiene un template donde se tiene los tabs(info/address) , en menu.jade , se tiene todo el menu del cliente , y ahi un ui-sref="app.profile.info" (no se puede llamar al app.profile que es quien tiene los tabs , porque se genera un error de angular que no se puede hacer eso con los abstract), es por eso que se debe poner unos de sus hijos que seria app.profile.info, y este herede todo el template del padre que son los tabs y muestre a el template de info a la vez , entonces al dar clic en cualquier boton de address tanto para editar o crear uno nuevo este crea un nuevo ion-nav que tiene la flecha , al regresar se queda en el tab clicleado que es el de direccion ,este template de direccion no tiene un nav , osea que se queda con el anterior creado que era del editar/crear y entonces no se puede salir y es donde se queda ahi , solo agregue un nav al template de direccion , para que este reemplace el nav anterior de la flecha y se pueda apreciar el icono del menu 